### PR TITLE
예약 대기열 기능을 구현했습니다.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,8 +32,10 @@ dependencies {
 
     implementation 'org.hibernate.orm:hibernate-spatial:'
 
-    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    // REDIS CACHE
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'org.springframework.boot:spring-boot-starter-cache'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/com/yscp/catchtable/application/queue/StoreQueueService.java
+++ b/src/main/java/com/yscp/catchtable/application/queue/StoreQueueService.java
@@ -1,9 +1,13 @@
 package com.yscp.catchtable.application.queue;
 
 import com.yscp.catchtable.application.queue.dto.StoreQueueDto;
+import com.yscp.catchtable.exception.BadRequestError;
+import com.yscp.catchtable.exception.CatchTableException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
+
+import java.time.Duration;
 
 @RequiredArgsConstructor
 @Service
@@ -11,6 +15,16 @@ public class StoreQueueService {
     private final RedisTemplate<String, String> redisTemplate;
 
     public void registerWaiting(StoreQueueDto storeQueueDto) {
-        redisTemplate.opsForZSet().add(storeQueueDto.key(), storeQueueDto.value(), storeQueueDto.score());
+
+        Boolean result = redisTemplate.opsForZSet().addIfAbsent(storeQueueDto.key(),
+                storeQueueDto.value(),
+                storeQueueDto.score());
+
+        if (Boolean.FALSE.equals(result)) {
+            throw new CatchTableException(BadRequestError.ALREADY_REGISTER_WAITING);
+        }
+
+        redisTemplate.expire(storeQueueDto.key(), Duration.ofMinutes(7L));
+
     }
 }

--- a/src/main/java/com/yscp/catchtable/application/queue/StoreQueueService.java
+++ b/src/main/java/com/yscp/catchtable/application/queue/StoreQueueService.java
@@ -1,0 +1,16 @@
+package com.yscp.catchtable.application.queue;
+
+import com.yscp.catchtable.application.queue.dto.StoreQueueDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class StoreQueueService {
+    private final RedisTemplate<String, String> redisTemplate;
+
+    public void registerWaiting(StoreQueueDto storeQueueDto) {
+        redisTemplate.opsForZSet().add(storeQueueDto.key(), storeQueueDto.value(), storeQueueDto.score());
+    }
+}

--- a/src/main/java/com/yscp/catchtable/application/queue/dto/StoreQueueDto.java
+++ b/src/main/java/com/yscp/catchtable/application/queue/dto/StoreQueueDto.java
@@ -1,0 +1,24 @@
+package com.yscp.catchtable.application.queue.dto;
+
+import java.time.Instant;
+
+public record StoreQueueDto(
+        Long storeIdx,
+        String date,
+        String time,
+        String userId
+) {
+    private static final String WAITING_KEY_FORMAT = "store:%s:waiting:%s:%s";
+
+    public String key() {
+        return String.format(WAITING_KEY_FORMAT, storeIdx, date, time);
+    }
+
+    public String value() {
+        return userId.toString();
+    }
+
+    public double score() {
+        return Instant.now().toEpochMilli();
+    }
+}

--- a/src/main/java/com/yscp/catchtable/application/queue/dto/StoreQueueDto.java
+++ b/src/main/java/com/yscp/catchtable/application/queue/dto/StoreQueueDto.java
@@ -6,7 +6,7 @@ public record StoreQueueDto(
         String storeReserveIdx,
         String userIdx
 ) {
-    private static final String WAITING_KEY_FORMAT = "store:%s:waiting:%s";
+    private static final String WAITING_KEY_FORMAT = "store:%s:waiting:v1:%s";
 
     public String key() {
         return String.format(WAITING_KEY_FORMAT, storeReserveIdx, userIdx);

--- a/src/main/java/com/yscp/catchtable/application/queue/dto/StoreQueueDto.java
+++ b/src/main/java/com/yscp/catchtable/application/queue/dto/StoreQueueDto.java
@@ -3,19 +3,17 @@ package com.yscp.catchtable.application.queue.dto;
 import java.time.Instant;
 
 public record StoreQueueDto(
-        Long storeIdx,
-        String date,
-        String time,
-        String userId
+        String storeReserveIdx,
+        String userIdx
 ) {
-    private static final String WAITING_KEY_FORMAT = "store:%s:waiting:%s:%s";
+    private static final String WAITING_KEY_FORMAT = "store:%s:waiting:%s";
 
     public String key() {
-        return String.format(WAITING_KEY_FORMAT, storeIdx, date, time);
+        return String.format(WAITING_KEY_FORMAT, storeReserveIdx, userIdx);
     }
 
     public String value() {
-        return userId.toString();
+        return userIdx;
     }
 
     public double score() {

--- a/src/main/java/com/yscp/catchtable/application/reserve/ReserveService.java
+++ b/src/main/java/com/yscp/catchtable/application/reserve/ReserveService.java
@@ -2,6 +2,7 @@ package com.yscp.catchtable.application.reserve;
 
 import com.yscp.catchtable.application.reserve.dto.ReserveDto;
 import com.yscp.catchtable.application.reserve.dto.StoreReserveDto;
+import com.yscp.catchtable.domain.reserve.entity.ReserveData;
 import com.yscp.catchtable.domain.reserve.repository.ReserveRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -29,5 +30,10 @@ public class ReserveService {
                 .stream()
                 .map(ReserveDto::from)
                 .toList();
+    }
+
+    public ReservesInDayDto getReservesInDay(Long storeIdx, LocalDate date) {
+        List<ReserveData> reserveDates = repository.findByStore_IdxAndReserveDate(storeIdx, date);
+        return ReservesInDayDto.from(reserveDates);
     }
 }

--- a/src/main/java/com/yscp/catchtable/application/reserve/ReservesInDayDto.java
+++ b/src/main/java/com/yscp/catchtable/application/reserve/ReservesInDayDto.java
@@ -1,0 +1,29 @@
+package com.yscp.catchtable.application.reserve;
+
+import com.yscp.catchtable.application.reserve.dto.ReserveInDayDto;
+import com.yscp.catchtable.domain.reserve.entity.ReserveData;
+import org.springframework.util.CollectionUtils;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public record ReservesInDayDto(
+        List<ReserveInDayDto> reserves
+) {
+    public static ReservesInDayDto from(List<ReserveData> reserveDates) {
+        if (CollectionUtils.isEmpty(reserveDates)) {
+            return new ReservesInDayDto(new ArrayList<>());
+        }
+
+        return new ReservesInDayDto(convert(reserveDates));
+    }
+
+    private static List<ReserveInDayDto> convert(List<ReserveData> reserveDates) {
+        return reserveDates.stream()
+                .map(reserveData -> new ReserveInDayDto(
+                        reserveData.getIdx(),
+                        reserveData.getReserveTime(),
+                        reserveData.getMaxUserCount()
+                )).toList();
+    }
+}

--- a/src/main/java/com/yscp/catchtable/application/reserve/dto/ReserveInDayDto.java
+++ b/src/main/java/com/yscp/catchtable/application/reserve/dto/ReserveInDayDto.java
@@ -1,0 +1,8 @@
+package com.yscp.catchtable.application.reserve.dto;
+
+public record ReserveInDayDto(
+        Long idx,
+        String reserveTime,
+        Integer maxUserCount
+) {
+}

--- a/src/main/java/com/yscp/catchtable/application/store/mapper/StoreQueueMapper.java
+++ b/src/main/java/com/yscp/catchtable/application/store/mapper/StoreQueueMapper.java
@@ -8,10 +8,8 @@ import lombok.experimental.UtilityClass;
 public class StoreQueueMapper {
     public static StoreQueueDto toQueueDto(StoreQueueRequestDto storeQueueRequestDto) {
         return new StoreQueueDto(
-                storeQueueRequestDto.storeIdx(),
-                storeQueueRequestDto.date(),
-                storeQueueRequestDto.time(),
-                storeQueueRequestDto.userId()
+                storeQueueRequestDto.storeReserveIdx().toString(),
+                storeQueueRequestDto.userIdx()
         );
     }
 }

--- a/src/main/java/com/yscp/catchtable/application/store/mapper/StoreQueueMapper.java
+++ b/src/main/java/com/yscp/catchtable/application/store/mapper/StoreQueueMapper.java
@@ -1,0 +1,17 @@
+package com.yscp.catchtable.application.store.mapper;
+
+import com.yscp.catchtable.application.queue.dto.StoreQueueDto;
+import com.yscp.catchtable.presentation.store.dto.StoreQueueRequestDto;
+import lombok.experimental.UtilityClass;
+
+@UtilityClass
+public class StoreQueueMapper {
+    public static StoreQueueDto toQueueDto(StoreQueueRequestDto storeQueueRequestDto) {
+        return new StoreQueueDto(
+                storeQueueRequestDto.storeIdx(),
+                storeQueueRequestDto.date(),
+                storeQueueRequestDto.time(),
+                storeQueueRequestDto.userId()
+        );
+    }
+}

--- a/src/main/java/com/yscp/catchtable/domain/reserve/entity/ReserveData.java
+++ b/src/main/java/com/yscp/catchtable/domain/reserve/entity/ReserveData.java
@@ -27,9 +27,9 @@ public class ReserveData {
     private Store store;
 
     @Comment("예약 일자")
-    private LocalDate reserveData;
+    private LocalDate reserveDate;
     @Comment("예약 시간")
-    private Integer reserveTime;
+    private String reserveTime;
     @Comment("최소 인원")
     private Integer minUserCount;
     @Comment("최대 인원")

--- a/src/main/java/com/yscp/catchtable/domain/reserve/repository/ReserveRepository.java
+++ b/src/main/java/com/yscp/catchtable/domain/reserve/repository/ReserveRepository.java
@@ -38,4 +38,6 @@ public interface ReserveRepository extends JpaRepository<ReserveData, Long> {
                     """
             , nativeQuery = true)
     List<StoreReserveDto> getStoreReserveDtoBeforeMaxDate(@Param("idx") Long idx, @Param("date") LocalDate date);
+
+    List<ReserveData> findByStore_IdxAndReserveDate(Long idx, LocalDate reserveDate);
 }

--- a/src/main/java/com/yscp/catchtable/exception/BadRequestError.java
+++ b/src/main/java/com/yscp/catchtable/exception/BadRequestError.java
@@ -11,7 +11,12 @@ public enum BadRequestError implements CustomError {
     /**
      * 0 ~ 100 Common
      */
-    NULL_EXCEPTION("%s", "1", true);
+    NULL_EXCEPTION("%s", "1", true),
+
+    /**
+     * 200 ~ 300 Waiting
+     */
+    ALREADY_REGISTER_WAITING("이미 예약을 진행하고 있습니다.", "200" , false);
 
     private final HttpStatus httpStatus = HttpStatus.BAD_REQUEST;
     private final String message;

--- a/src/main/java/com/yscp/catchtable/exception/BadRequestError.java
+++ b/src/main/java/com/yscp/catchtable/exception/BadRequestError.java
@@ -11,11 +11,11 @@ public enum BadRequestError implements CustomError {
     /**
      * 0 ~ 100 Common
      */
-    NULL_EXCEPTION("%s", 1, true);
+    NULL_EXCEPTION("%s", "1", true);
 
     private final HttpStatus httpStatus = HttpStatus.BAD_REQUEST;
     private final String message;
-    private final Integer errorCode;
+    private final String errorCode;
     private final Boolean isCustomMessage;
 
     @Override

--- a/src/main/java/com/yscp/catchtable/exception/CustomError.java
+++ b/src/main/java/com/yscp/catchtable/exception/CustomError.java
@@ -3,13 +3,10 @@ package com.yscp.catchtable.exception;
 import org.springframework.http.HttpStatus;
 
 public interface CustomError {
-    HttpStatus getHttpStatus();
-
-    String getErrorCode();
-
-    String getMessage();
-
-    default Boolean isCustomMessage() {
+     HttpStatus getHttpStatus();
+     String getErrorCode();
+     String getMessage();
+     default Boolean isCustomMessage() {
         return false;
     }
 }

--- a/src/main/java/com/yscp/catchtable/exception/NotFoundError.java
+++ b/src/main/java/com/yscp/catchtable/exception/NotFoundError.java
@@ -4,15 +4,15 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 
-@RequiredArgsConstructor
 @Getter
+@RequiredArgsConstructor
 public enum NotFoundError implements CustomError {
-    NOT_FOUND_STORE("상점을 찾을 수 없습니다.", 100, false),
-    NOT_FOUND_BUSINESS_HOUR("영업 시간을 조회할 수 없습니다.", 101, false);
+    NOT_FOUND_STORE("상점을 찾을 수 없습니다.", "100", false),
+    NOT_FOUND_BUSINESS_HOUR("영업 시간을 조회할 수 없습니다.", "101", false);
 
     private final HttpStatus httpStatus = HttpStatus.NOT_FOUND;
     private final String message;
-    private final Integer errorCode;
+    private final String errorCode;
     private final Boolean isCustomMessage;
 
     @Override

--- a/src/main/java/com/yscp/catchtable/presentation/reserve/ReserveController.java
+++ b/src/main/java/com/yscp/catchtable/presentation/reserve/ReserveController.java
@@ -1,0 +1,29 @@
+package com.yscp.catchtable.presentation.reserve;
+
+import com.yscp.catchtable.application.reserve.ReserveService;
+import com.yscp.catchtable.application.reserve.ReservesInDayDto;
+import com.yscp.catchtable.presentation.reserve.dto.response.ReserveInDayResponseDtos;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDate;
+
+@RequiredArgsConstructor
+@RestController
+public class ReserveController {
+
+    private final ReserveService reserveService;
+
+    @GetMapping("/store/reserves/{storeIdx}")
+    public ResponseEntity<ReserveInDayResponseDtos> getReservesInDay(@PathVariable Long storeIdx,
+                                                                     @RequestParam LocalDate date) {
+
+        ReservesInDayDto reservesInDay = reserveService.getReservesInDay(storeIdx, date);
+
+        return ResponseEntity.ok(ReserveInDayResponseDtos.from(reservesInDay));
+    }
+}

--- a/src/main/java/com/yscp/catchtable/presentation/reserve/dto/response/ReserveInDayResponseDto.java
+++ b/src/main/java/com/yscp/catchtable/presentation/reserve/dto/response/ReserveInDayResponseDto.java
@@ -1,0 +1,8 @@
+package com.yscp.catchtable.presentation.reserve.dto.response;
+
+public record ReserveInDayResponseDto(
+        Long idx,
+        String reserveTime,
+        Integer maxUserCount
+) {
+}

--- a/src/main/java/com/yscp/catchtable/presentation/reserve/dto/response/ReserveInDayResponseDtos.java
+++ b/src/main/java/com/yscp/catchtable/presentation/reserve/dto/response/ReserveInDayResponseDtos.java
@@ -1,0 +1,28 @@
+package com.yscp.catchtable.presentation.reserve.dto.response;
+
+import com.yscp.catchtable.application.reserve.ReservesInDayDto;
+import com.yscp.catchtable.application.reserve.dto.ReserveInDayDto;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public record ReserveInDayResponseDtos(
+        List<ReserveInDayResponseDto> reserves
+) {
+    public static ReserveInDayResponseDtos from(ReservesInDayDto reservesInDay) {
+        if (reservesInDay == null) {
+            return new ReserveInDayResponseDtos(new ArrayList<>());
+        }
+
+        return new ReserveInDayResponseDtos(convert(reservesInDay.reserves()));
+    }
+
+    private static List<ReserveInDayResponseDto> convert(List<ReserveInDayDto> reservesInDay) {
+        return reservesInDay.stream()
+                .map(reserveInDayDto -> new ReserveInDayResponseDto(
+                        reserveInDayDto.idx(),
+                        reserveInDayDto.reserveTime(),
+                        reserveInDayDto.maxUserCount()
+                )).toList();
+    }
+}

--- a/src/main/java/com/yscp/catchtable/presentation/store/StoreQueueController.java
+++ b/src/main/java/com/yscp/catchtable/presentation/store/StoreQueueController.java
@@ -1,0 +1,22 @@
+package com.yscp.catchtable.presentation.store;
+
+import com.yscp.catchtable.application.queue.StoreQueueService;
+import com.yscp.catchtable.application.store.mapper.StoreQueueMapper;
+import com.yscp.catchtable.presentation.store.dto.StoreQueueRequestDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+public class StoreQueueController {
+    private final StoreQueueService storeQueueService;
+
+    @PostMapping("/store/reservation/enter")
+    public ResponseEntity<Void> enter(@RequestBody StoreQueueRequestDto storeQueueRequestDto) {
+        storeQueueService.registerWaiting(StoreQueueMapper.toQueueDto(storeQueueRequestDto));
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/yscp/catchtable/presentation/store/dto/StoreQueueRequestDto.java
+++ b/src/main/java/com/yscp/catchtable/presentation/store/dto/StoreQueueRequestDto.java
@@ -1,9 +1,7 @@
 package com.yscp.catchtable.presentation.store.dto;
 
 public record StoreQueueRequestDto(
-        Long storeIdx,
-        String date,
-        String time,
-        String userId
+        Long storeReserveIdx,
+        String userIdx
 ) {
 }

--- a/src/main/java/com/yscp/catchtable/presentation/store/dto/StoreQueueRequestDto.java
+++ b/src/main/java/com/yscp/catchtable/presentation/store/dto/StoreQueueRequestDto.java
@@ -1,0 +1,9 @@
+package com.yscp.catchtable.presentation.store.dto;
+
+public record StoreQueueRequestDto(
+        Long storeIdx,
+        String date,
+        String time,
+        String userId
+) {
+}

--- a/src/test/java/com/yscp/catchtable/domain/reserve/repository/ReserveRepositoryTest.java
+++ b/src/test/java/com/yscp/catchtable/domain/reserve/repository/ReserveRepositoryTest.java
@@ -27,6 +27,14 @@ class ReserveRepositoryTest {
     void getStoreReserveDtoBeforeMaxDate() {
         Assertions.assertThatCode(() -> reserveRepository.getStoreReserveDtoBeforeMaxDate(1L, LocalDate.of(2025, 6, 20)))
                 .doesNotThrowAnyException();
+    }
+
+    @DisplayName("findByStore_IdxAndReserveDate")
+    @Test
+    void findByStore_IdxAndReserveDate() {
+        Assertions.assertThatCode(() -> reserveRepository.findByStore_IdxAndReserveDate(1L, LocalDate.of(2025, 6, 20)))
+                .doesNotThrowAnyException();
 
     }
 }
+


### PR DESCRIPTION
## 작업 내용
- 대기열 기능 구현
  - 예약하기 이전  사용자의 예약 유효기간 및, 선착순 기능을 제어하기 위해 필요한 대기열 등록 기능 구현
  - 해당 대기열에서 예약 가능한 순번에 도래했을 경우 예약이 가능 
  - 해당 대기열에서 예약을 했을 경우 value삭제
  - 해당 대기열에서 시간이 만료됐을 경우 배치를 통하여 데이터 삭제

-  예약 조회 기능 구현
  -  상점에서 일자별 예약 조회 기능 구현
  - 일자 별로 예약 가능한 리스트 조회 가능


## 구현 예정

- 대기열 조회
- 예약하기 기능 구현